### PR TITLE
Add back to index link to new questions, create pull request template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1728,9 +1728,9 @@ const fetchMovies = ({ signal }) => {
 
 De esta forma evitamos que se produzca un error por parte de React de intentar actualizar el estado de un componente que ya no existe, además de evitar que se produzcan llamadas innecesarias al servidor.
 
----
-
 **[⬆ Volver a índice](#índice)**
+
+---
 
 #### ¿Qué solución/es implementarías para evitar problemas de rendimiento al trabajar con listas de miles/millones de datos?
 

--- a/README.md
+++ b/README.md
@@ -1730,6 +1730,8 @@ De esta forma evitamos que se produzca un error por parte de React de intentar a
 
 ---
 
+**[⬆ Volver a índice](#índice)**
+
 #### ¿Qué solución/es implementarías para evitar problemas de rendimiento al trabajar con listas de miles/millones de datos?
 
 ##### Pagination
@@ -2144,3 +2146,5 @@ const fetchMovies = ({ signal }) => {
 ```
 
 Sólo ten en cuenta la compatibilidad de `AbortController` en los navegadores. En [caniuse](https://caniuse.com/#feat=abortcontroller) puedes ver que no está soportado en Internet Explorer y versiones anteriores de Chrome 66, Safari 12.1 y Edge 16.
+
+**[⬆ Volver a índice](#índice)**

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,9 @@
+## Description
+
+Please include a quick summary of the change.
+
+## Checklist:
+
+- [ ] I checked that the question is not repeated
+- [ ] I double checked that the grammar in my changes is correct
+- [ ] I have added a "Back to Index" link (`**[⬆ Volver a índice](#índice)**`) and a thematic break line (`---`) at the end of my question

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,14 @@
-## Description
+## Descripción
 
-Please include a quick summary of the change.
+Por favor incluye una descripción breve de tus cambios
 
 ## Checklist:
 
-- [ ] I checked that the question is not repeated
-- [ ] I double checked that the grammar in my changes is correct
-- [ ] I have added a "Back to Index" link (`**[⬆ Volver a índice](#índice)**`) and a thematic break line (`---`) at the end of my question
+- [ ] He revisado que mi pregunta no está duplicada
+- [ ] He revisado que la gramática de mis cambios es correcta
+- [ ] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una linea separadora (`---`) al final de mi pregunta
+
+
+
+
+


### PR DESCRIPTION
## Descripción

Originalmente hice este PR para agregar "Voler al Indice" a las dos nuevas preguntas, pero me encontré con que  [¿Cómo puedes abortar una petición fetch con useEffect en React?"](https://github.com/midudev/preguntas-entrevista-react#c%C3%B3mo-puedes-abortar-una-petici%C3%B3n-fetch-con-useeffect-en-react) está repetida con "[Cómo puedes cancelar una petición a una API en useEffect correctamente](https://github.com/midudev/preguntas-entrevista-react#c%C3%B3mo-puedes-cancelar-una-petici%C3%B3n-a-una-api-en-useeffect-correctamente)" 
Eliminamos una complementandola? Deberia ser intermedio o expert?

Sugiero igual una pull request template para ir agregando los estandares que se crean convenientes

## Checklist:

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
- [x] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una linea separadora (`---`) al final de mi pregunta


