### PR TITLE
Bugfix - "href" incorrecto en la entrada "¿Qué es el Compound Components Pattern?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     - [¿Qué hace el hook `useId`?](#qué-hace-el-hook-useid)
     - [¿Cómo podemos ejecutar código cuando el componente se monta?](#cómo-podemos-ejecutar-código-cuando-el-componente-se-monta)
     - [¿Qué son los Fragments en React?](#qué-son-los-fragments-en-react)
-    - [¿Qué es el Compound Components Pattern?](#¿qué-es-el-compound-components-pattern?)
+    - [¿Qué es el Compound Components Pattern?](#qué-es-el-compound-components-pattern)
     - [¿Cómo puedes inicializar un proyecto de React desde cero?](#cómo-puedes-inicializar-un-proyecto-de-react-desde-cero)
     - [¿Qué es React DOM?](#qué-es-react-dom)
   - [Intermedio](#intermedio)


### PR DESCRIPTION
## Descripción

Se ha detectado un bug en el TOC, en la entrada "¿Qué es el Compound Components Pattern?", ya que no envía a la descripción correcta. Se ha arreglado.

### Pasos para reproducirlo
- Ir al TOC en https://github.com/midudev/preguntas-entrevista-react#readme
- Buscar "¿Qué es el Compound Components Pattern?"
- Al hacer click, no te lleva a su descripción.
  - Enlace incorrecto: https://github.com/midudev/preguntas-entrevista-react#%C2%BFqu%C3%A9-es-el-compound-components-pattern?
  - Enlace correcto: https://github.com/midudev/preguntas-entrevista-react#qu%C3%A9-es-el-compound-components-pattern

## Checklist

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
- [x] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una linea separadora (`---`) al final de mi pregunta
