### PR TITLE
fix client side exception during searching

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -30,7 +30,7 @@ export function Header () {
   )
 
   const handleSelect = (result) => {
-    router.push(`/${result}/#content`)
+    if (result) router.push(`/${result}/#content`)
   }
 
   return (


### PR DESCRIPTION
## Descripción

Al eliminar la query de la caja de texto, arroja la siguiente excepción en desarrollo:

https://user-images.githubusercontent.com/68721455/199884440-b03e5917-6e76-4d54-bc34-3e7d6d9eb556.mp4

y en producción:

![image](https://user-images.githubusercontent.com/68721455/199881122-8cd2e553-181f-4b55-a5a8-3ab29267bd72.png)

Al seleccionar un item del combobox, se ejecuta la función `handleSelect` y la web nos lleva a la URL con el contenido pero cuando el usuario elimina la query de la caja de texto, el parámetro **result** devuelve null y lanza una excepción.

El resultado 😄 

https://user-images.githubusercontent.com/68721455/199886304-269b18e9-f1a3-45e7-ad88-7c6324ecd289.mp4
