### PR TITLE
Se agrega funcionalidad para saber cuantas preguntas hay y cuantas he marcado como leídas

### DIFF
--- a/app/[post]/page.js
+++ b/app/[post]/page.js
@@ -2,6 +2,7 @@ import { readJSON } from 'fs-extra'
 import path from 'node:path'
 
 import { Pill } from '../components/Pill.jsx'
+import { ButtonRead } from '../components/ButtonRead.jsx'
 
 const jsonDirectory = path.join(process.cwd(), 'dist')
 
@@ -19,7 +20,10 @@ export default async function Post ({ params }) {
     <>
       <header className='relative'>
         <h1 className='pb-8 text-4xl font-bold text-blue-900 font-grotesk' id='content'>{title}</h1>
-        <Pill level={level} />
+        <div className='absolute top-3 right-1 flex flex-row gap-2'>
+          <Pill level={level} />
+          <ButtonRead title={title} />
+        </div>
       </header>
       <article className='prose max-w-none pb-4 [&>h1]:text-3xl [&>h1]:font-bold [&>h1]:text-blue-900 [&>h1]:pb-8 [&>p]:pb-6 [&>p]:text-xl [&>p>strong]:bg-yellow-50 [&_a]:text-blue-700 [&_a:hover]:underline [&>ul>li]:list-disc [&>ul]:text-xl [&>ul]:text-blue-900 [&>ul]:pb-4 [&>ul>li]:list-inside [&>pre]:rounded [&>pre]:text-white [&>pre]:mb-8 [&>pre]:p-4 [&>pre]:bg-slate-800' dangerouslySetInnerHTML={{ __html: render }} />
     </>

--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export function ButtonRead ({ title }) {
+  const [read, setRead] = useState([])
+  const [isFavorite, setIsRead] = useState(false)
+
+  useEffect(() => {
+    const readStorage = JSON.parse(localStorage.getItem('read')) || []
+    setRead(readStorage)
+    setIsRead(readStorage.includes(title))
+  }, [title])
+
+  const handleSetRead = (title) => {
+    if (title) {
+      const isFavorite = read.includes(title)
+      if (!isFavorite) {
+        read.push(title)
+        setIsRead(true)
+      } else {
+        read.splice(read.indexOf(title), 1)
+        setIsRead(false)
+      }
+      localStorage.setItem('read', JSON.stringify(read))
+    }
+  }
+
+  const color = !isFavorite ? 'bg-white' : 'bg-green-200'
+  return (
+    <div>
+      <button
+        onClick={() => handleSetRead(title)}
+        className={`${color} border uppercase mix rounded-[4px] font-bold font-grotesk inline-block p-[3px] text-[10px]`}
+      >
+        {!isFavorite ? 'Marcar leído' : 'Marcar no leído'}
+      </button>
+    </div>
+  )
+}

--- a/app/components/Footer.jsx
+++ b/app/components/Footer.jsx
@@ -26,7 +26,7 @@ export async function Footer () {
 
         <a className='flex items-center justify-center transition-colors bg-gray-100 border border-gray-200 rounded hover:bg-gray-200' href='https://github.com/midudev/preguntas-entrevista-react' target='_blank' rel='noreferrer'>
           <span className='flex items-center justify-center px-3 py-1 overflow-hidden text-xs font-semibold text-gray-700 border-r border-r-gray-300 gap-x-1'>
-            <svg viewBox='0 0 16 16' width='16' height='16' class='octicon octicon-star' aria-hidden='true'><path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z' /></svg>
+            <svg viewBox='0 0 16 16' width='16' height='16' className='octicon octicon-star' aria-hidden='true'><path fillRule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z' /></svg>
             Star
           </span>
 

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useId, useCallback, useState } from 'react'
+import { useId, useCallback, useState, useEffect } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import debounce from 'just-debounce-it'
 import Link from 'next/link'
 import { Combobox } from '@headlessui/react'
+import counter from '../../dist/counter.json'
 
 import { ReactLogo } from './ReactLogo.jsx'
 import { SearchIcon } from './SearchIcon.jsx'
@@ -13,6 +14,7 @@ import { Title } from './Title.jsx'
 export function Header () {
   const searchId = useId('search-id')
   const pathname = usePathname()
+  const [read, setRead] = useState(0)
   const [results, setResults] = useState([])
   const router = useRouter()
 
@@ -29,13 +31,28 @@ export function Header () {
     []
   )
 
+  useEffect(() => {
+    const readStorage = JSON.parse(localStorage.getItem('read')) || []
+    setRead(readStorage.length)
+  }, [])
+
   const handleSelect = (result) => {
     if (result) router.push(`/${result}/#content`)
   }
 
   return (
-    <header className='pt-20 pb-20'>
+    <header className='relative pt-20 pb-20'>
+
+      <div className='absolute top-1 right-0'>
+        <button
+          className='border uppercase mix rounded-[4px] font-bold font-grotesk inline-block p-[3px] text-[10px]'
+        >
+          Leidas {read}/{counter.total}
+        </button>
+      </div>
+
       <div className='relative'>
+
         <a className='hover:underline' href='/'>{literal}</a>
         <Title />
 

--- a/app/components/Pill.jsx
+++ b/app/components/Pill.jsx
@@ -19,7 +19,7 @@ export function Pill ({ level }) {
   const literal = LITERALS[level] ?? LITERALS[LEVELS.EASY]
 
   return (
-    <div className='absolute top-3 right-3'>
+    <div>
       <span className={`${color} border uppercase mix rounded-[4px] font-bold font-grotesk inline-block p-[3px] text-[10px]`}>
         {literal}
       </span>

--- a/scripts/markdownToJson.mjs
+++ b/scripts/markdownToJson.mjs
@@ -33,8 +33,11 @@ let previousTitle = ''
 const index = []
 let levelLiteral = 'principiante'
 let stack = []
+const counter = {
+  total: 0
+}
 
-const promises = tree.map((item) => {
+const promises = tree.map((item, i) => {
   const { depth, type, text } = item
 
   const isHeading = type === 'heading'
@@ -48,6 +51,8 @@ const promises = tree.map((item) => {
   if (isHeading) {
     const id = slugify(text)
     const level = MAP_LEVELS[levelLiteral]
+
+    counter.total++
 
     index.push({ id, text, level })
 
@@ -75,6 +80,7 @@ const promises = tree.map((item) => {
 }).filter(Boolean)
 
 Promise.all(promises).then(() => {
+  fs.outputJSON('./dist/counter.json', counter)
   fs.outputJSON('./dist/index.json', index)
   console.log('All files generated')
 })


### PR DESCRIPTION
Se agrega una nueva funcionalidad que permite guardar en el LocalStorage las preguntas leídas, y también un contador de todas las preguntas que se guarda cuando se hace la generación de las preguntas en json genera un nuevo archivo llamado counter.json

## Issues
Close #45 

## Checklist

- [x] He agregado un botón en la página post que permite marcar la pregunta como leída
- [x] He agregado una modificación en markdownToJson para guardar el total de preguntas procesadas
- [x] He agregado un contador en el header para saber cuantas preguntas hay y cuantas llevo leídas
