### PR TITLE
Fix show route in search box when use the keyboard

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -24,6 +24,7 @@ export function Header ({ stars }) {
 
   const debouncedHandleChange = useCallback(
     debounce((event) => {
+      event.preventDefault()
       fetch(`/api/search?q=${event.target.value}`)
         .then(res => res.json())
         .then(resultsFromApi => {
@@ -43,8 +44,8 @@ export function Header ({ stars }) {
     setRead(readStorage.length)
   }, [])
 
-  const handleSelect = (result) => {
-    if (result) router.push(`/${result}/#content`)
+  const handleSelect = (result,) => {
+    if (result) router.push(`/${result.id}/#content`)
   }
 
   return (
@@ -98,6 +99,7 @@ export function Header ({ stars }) {
             onChange={debouncedHandleChange}
             placeholder='Introduce aquí tu pregunta sobre React'
             type='search'
+            displayValue={(element) => element?.text}
           />
         </label>
 
@@ -113,7 +115,7 @@ export function Header ({ stars }) {
                 const html = text.slice(0, bestMatch[0]) + '<span class="bg-yellow-200">' + text.slice(bestMatch[0], bestMatch[1] + 1) + '</span>' + text.slice(bestMatch[1] + 1)
 
                 return (
-                  <Combobox.Option key={id} value={id}>
+                  <Combobox.Option key={id} value={{ id, text }}>
                     {({ active, selected }) => (
                       <Link className={`block p-4 hover:bg-gray-100 ${active ? 'bg-gray-100' : 'bg-white'}`} href={`/${id}/#content`}>
                         {selected && <span className='sr-only'>Seleccionado</span>}

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -24,7 +24,6 @@ export function Header ({ stars }) {
 
   const debouncedHandleChange = useCallback(
     debounce((event) => {
-      event.preventDefault()
       fetch(`/api/search?q=${event.target.value}`)
         .then(res => res.json())
         .then(resultsFromApi => {
@@ -44,7 +43,7 @@ export function Header ({ stars }) {
     setRead(readStorage.length)
   }, [])
 
-  const handleSelect = (result,) => {
+  const handleSelect = (result) => {
     if (result) router.push(`/${result.id}/#content`)
   }
 


### PR DESCRIPTION
## Descripción

Evita mostrar la ruta en el cuadro de búsqueda cuando se usa el teclado para seleccionar el resultado de una búsqueda.

En su lugar muestra el título de la página.

## Checklist
_No procede_
