### PR TITLE
Fix different mouse/keyboard behavior in search element selection

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -116,10 +116,10 @@ export function Header ({ stars }) {
                 return (
                   <Combobox.Option key={id} value={{ id, text }}>
                     {({ active, selected }) => (
-                      <Link className={`block p-4 hover:bg-gray-100 ${active ? 'bg-gray-100' : 'bg-white'}`} href={`/${id}/#content`}>
+                      <span className={`block p-4 hover:bg-gray-100 ${active ? 'bg-gray-100' : 'bg-white'}`} href={`/${id}/#content`}>
                         {selected && <span className='sr-only'>Seleccionado</span>}
                         <strong dangerouslySetInnerHTML={{ __html: html }} />
-                      </Link>
+                      </span>
                     )}
 
                   </Combobox.Option>


### PR DESCRIPTION
## Descripción

Al seleccionar un resultado de una búsqueda, el comportamiento es distinto en función de si el usuario usa el teclado o el ratón.

## Causa
* Si el usuario usa el ratón, al estarse usando un componente `Link`, no se realiza la selección del Headless Combobox (Link hace su magia antes 😿 ).
* Si el usuario usa el teclado, como es un una funcionalidad del Headless Combobox, se ejecuta la lógica asociada al evento de selección del mismo.

## Ejemplo

### Ahora

![con-link-actual](https://user-images.githubusercontent.com/1440142/202230339-8a7abc3e-a889-463d-9e7e-912a5f4192c8.gif)

### Después

![sin-link](https://user-images.githubusercontent.com/1440142/202231641-61c088c2-4915-4524-9f61-88b1dca16e26.gif)

## Checklist

_No procede_
