### PR TITLE
Se arregla el fallo en el estilo de la parte inferior del cuadro de búsqueda

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -94,7 +94,9 @@ export function Header ({ stars }) {
           </div>
           <Combobox.Input
             autoFocus
-            className={`search-input z-10 block w-full p-4 md:p-6 pl-14 md:pl-20 text-base md:text-xl font-bold bg-white border border-gray-300 rounded-3xl outline-none appearance-none hover:shadow-lg focus:shadow-blue-100 focus:border-blue-300 ${results.length && 'border-b-0 rounded-b-none'}`}
+            className={`search-input z-10 block w-full p-4 md:p-6 pl-14 md:pl-20 text-base md:text-xl font-bold bg-white border border-gray-300 rounded-3xl outline-none appearance-none hover:shadow-lg focus:shadow-blue-100 focus:border-blue-300 ${
+              results.length && 'focus:border-b-0 focus:rounded-b-none'
+            }`}
             onChange={debouncedHandleChange}
             placeholder='Introduce aquí tu pregunta sobre React'
             type='search'


### PR DESCRIPTION
## Descripción

Se arregla los estilos de la parte inferior del cuadro de búsqueda cuando se busca una pregunta.

## Causa

El problema que vi es que se le establece un border none y un border-radius 0 cuando en el cuadro de búsqueda se busca algo y aparecen las preguntas sugeridas pero no se quita estos estilos cuando ya no tiene el foco.

## Solución

Para arreglarlo acote esos dos estilos solo cuando hay matches de preguntas y el cuadro de búsqueda tiene el foco.

## Checklist

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
