### PR TITLE
FIX: Prevenir el doble <head> & <!DOCTYPE> mal definido

### DIFF
--- a/app/components/Head.jsx
+++ b/app/components/Head.jsx
@@ -1,6 +1,6 @@
 export const Head = ({ title, description, ogImage }) => {
   return (
-    <head>
+    <>
       <title>{title}</title>
       <meta name='description' content={description} />
       <meta name='viewport' content='width=device-width,minimum-scale=1,initial-scale=1' />
@@ -17,6 +17,6 @@ export const Head = ({ title, description, ogImage }) => {
       <meta name='twitter:description' content={description} />
       <link href='favicon.ico' rel='icon' media='(prefers-color-scheme: light)' />
       <link href='favicon.dark.ico' rel='icon' media='(prefers-color-scheme: dark)' />
-    </head>
+    </>
   )
 }

--- a/app/layout.js
+++ b/app/layout.js
@@ -3,6 +3,7 @@ import { Space_Grotesk as SpaceGrotesk } from '@next/font/google'
 import { Header } from './components/Header.jsx'
 import { Footer } from './components/Footer.jsx'
 import { BuyBook } from './components/BuyBook.jsx'
+import { Head } from './components/Head'
 
 const spaceGrotesk = SpaceGrotesk({ weight: ['400', '700'], subsets: ['latin'] })
 
@@ -17,7 +18,9 @@ export default async function RootLayout ({ children }) {
 
   return (
     <html>
-      <head />
+      <head>
+        <Head />
+      </head>
       <body className={`${spaceGrotesk.className} overscroll-none`}>
         <div aria-hidden='true' className='absolute inset-0 z-0 overflow-hidden pointer-events-none'>
           <div className='absolute top-0 scale-150 rounded-full bg-blue-gradient-radial w-96 h-96 left-14 opacity-20' />


### PR DESCRIPTION
## Descripción

Cambios en la estructura de código de cómo se renderiza la cabecera `<head>`, ya que estaba renderizando 2 veces el `<head>` y la definición del `<!DOCTYPE>` en una mala ubicación

![image](https://user-images.githubusercontent.com/78863576/214981509-6a8d75b4-481c-4fe3-b63d-755f370554aa.png)

Con este cambio previene algún error en el futuro con navegadores ya que identifica la página como **no estandar** de [Lighthouse PageSpeed](https://pagespeed.web.dev/)


