### PR TITLE
Fix list rendering Objects array example

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ function List({ items }) {
 }
 ```
 
-En este caso, se renderiza una lista de elementos usando el componente `List`. El componente `List` recibe una prop `items` que es un array de objetos del tipo `[{id:1, name: "John", id:1, name: "Doe"}]`. El componente `List` renderiza un elemento `li` por cada elemento del array.
+En este caso, se renderiza una lista de elementos usando el componente `List`. El componente `List` recibe una prop `items` que es un array de objetos del tipo `[{ id: 1, name: "John Doe" }]`. El componente `List` renderiza un elemento `li` por cada elemento del array.
 
 El elemento `li` tiene una prop `key` que es un identificador único para cada elemento. Esto es necesario para que React pueda identificar cada elemento de la lista y actualizarlo de forma eficiente. Más adelante hay una explicación más detallada sobre esto.
 


### PR DESCRIPTION
## Descripción

He cambiado el ejemplo de array de objetos de la pregunta [¿Qué es el renderizado de listas en React?](https://github.com/midudev/preguntas-entrevista-react#qu%C3%A9-es-el-renderizado-de-listas-en-react): `[{id:1, name: "John", id:1, name: "Doe"}]`, ya que se trata de un objeto con los campos `id` y `name` duplicados.
En su lugar, lo he reemplazado por `[{ id: 1, name: "John Doe" }]`. Otra posible opción sería cambiarlo a un array con 2 objetos.

## Checklist

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
