### PR TITLE
Missing to import lazy and Suspense in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2558,7 +2558,7 @@ Este componente `SuperBigModal` se importa de forma estática, por lo que se car
 Si queremos ofrecer la mejor experiencia a nuestros usuarios, debemos intentar que la aplicación cargue lo más rápido posible. Por eso, es recomendable importar de forma dinámica los componentes que no se van a usar desde el principio.
 
 ```jsx
-import { useState } from 'react'
+import { useState, lazy, Suspense } from 'react'
 // importamos de forma dinámica el componente de la Modal
 const SuperBigModal = lazy(() => import('./super-big-modal.jsx'))
 


### PR DESCRIPTION
## Descripción

Por favor incluye una descripción breve de tus cambios
Se agregó el import de lazy y Suspense en un ejemplo de React

## Checklist

- [x ] He revisado que mi pregunta no está duplicada
- [ x] He revisado que la gramática de mis cambios es correcta
- [ x] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una línea separadora (`---`) al final de mi pregunta
