### PR TITLE
Fix no actualiza leidos entre pestañas

### DIFF
--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { useEventListener } from '../../hooks/useEventListener'
 
 export function ButtonRead ({ title }) {
   const [isFavorite, setIsRead] = useState(false)
@@ -10,17 +11,16 @@ export function ButtonRead ({ title }) {
     setIsRead(readStorage.includes(title))
   }, [title])
 
-  useEffect(() => {
-    window.addEventListener('storage', (event) => {
-      if (event.key === 'read') {
-        setIsRead(JSON.parse(event.newValue).includes(title))
-      }
-    })
-
-    return () => {
-      window.removeEventListener('storage', () => {})
+  const handlerStorageListener = useCallback((event) => {
+    if (event.key === 'read') {
+      setIsRead(JSON.parse(event.newValue).includes(title))
     }
   }, [title])
+
+  useEventListener({
+    eventName: 'storage',
+    handler: handlerStorageListener
+  })
 
   const handleSetRead = (title) => {
     if (title) {

--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -7,7 +7,7 @@ export function ButtonRead ({ title }) {
   const [isFavorite, setIsRead] = useState(false)
 
   useEffect(() => {
-    const readStorage = JSON.parse(localStorage.getItem('read') || [])
+    const readStorage = JSON.parse(localStorage.getItem('read')) || []
     setIsRead(readStorage.includes(title))
   }, [title])
 
@@ -24,7 +24,7 @@ export function ButtonRead ({ title }) {
 
   const handleSetRead = (title) => {
     if (title) {
-      const read = JSON.parse(localStorage.getItem('read') || [])
+      const read = JSON.parse(localStorage.getItem('read')) || []
       const isFavorite = read.includes(title)
       if (isFavorite) {
         read.splice(read.indexOf(title), 1)

--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -10,6 +10,18 @@ export function ButtonRead ({ title }) {
     setIsRead(readStorage.includes(title))
   }, [title])
 
+  useEffect(() => {
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'read') {
+        setIsRead(JSON.parse(event.newValue).includes(title))
+      }
+    })
+
+    return () => {
+      window.removeEventListener('storage', () => {})
+    }
+  }, [title])
+
   const handleSetRead = (title) => {
     if (title) {
       const read = JSON.parse(localStorage.getItem('read') || [])

--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -3,30 +3,31 @@
 import { useState, useEffect } from 'react'
 
 export function ButtonRead ({ title }) {
-  const [read, setRead] = useState([])
   const [isFavorite, setIsRead] = useState(false)
 
   useEffect(() => {
-    const readStorage = JSON.parse(localStorage.getItem('read')) || []
-    setRead(readStorage)
+    const readStorage = JSON.parse(localStorage.getItem('read') || [])
     setIsRead(readStorage.includes(title))
   }, [title])
 
   const handleSetRead = (title) => {
     if (title) {
+      const read = JSON.parse(localStorage.getItem('read') || [])
       const isFavorite = read.includes(title)
-      if (!isFavorite) {
-        read.push(title)
-        setIsRead(true)
-      } else {
+      if (isFavorite) {
         read.splice(read.indexOf(title), 1)
         setIsRead(false)
+      } else {
+        read.push(title)
+        setIsRead(true)
       }
       localStorage.setItem('read', JSON.stringify(read))
     }
   }
 
-  const color = !isFavorite ? 'dark:bg-secondry bg-white' : 'dark:text-primary bg-green-200'
+  const color = !isFavorite
+    ? 'dark:bg-secondry bg-white'
+    : 'dark:text-primary bg-green-200'
   return (
     <div>
       <button

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -11,7 +11,7 @@ import { ReactLogo } from './ReactLogo.jsx'
 import { SearchIcon } from './SearchIcon.jsx'
 import { Title } from './Title.jsx'
 import { Stars } from './Stars.jsx'
-import ThemeToggle from "./ThemeToggle";
+import ThemeToggle from './ThemeToggle'
 
 export function Header ({ stars }) {
   const pathname = usePathname()
@@ -42,7 +42,19 @@ export function Header ({ stars }) {
   useEffect(() => {
     const readStorage = JSON.parse(localStorage.getItem('read')) || []
     setRead(readStorage.length)
-  })
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'read') {
+        setRead(JSON.parse(event.newValue).length)
+      }
+    })
+
+    return () => {
+      window.removeEventListener('storage', () => {})
+    }
+  }, [])
 
   const handleSelect = (result) => {
     if (result) router.push(`/${result.id}/#content`)
@@ -54,7 +66,7 @@ export function Header ({ stars }) {
       {
         isHome && (
           <div className='absolute right-0 flex items-center gap-x-2 top-1'>
-            <ThemeToggle/>
+            <ThemeToggle />
             <Stars stars={stars} />
             <button
               className='border uppercase mix rounded-[4px] font-bold inline-block p-2 text-[10px]'

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -12,6 +12,7 @@ import { SearchIcon } from './SearchIcon.jsx'
 import { Title } from './Title.jsx'
 import { Stars } from './Stars.jsx'
 import ThemeToggle from './ThemeToggle'
+import { useEventListener } from '../../hooks/useEventListener'
 
 export function Header ({ stars }) {
   const pathname = usePathname()
@@ -34,6 +35,17 @@ export function Header ({ stars }) {
     []
   )
 
+  const handlerStorageListener = useCallback((event) => {
+    if (event.key === 'read') {
+      setRead(JSON.parse(event.newValue).length)
+    }
+  }, [])
+
+  useEventListener({
+    eventName: 'storage',
+    handler: handlerStorageListener
+  })
+
   useEffect(() => {
     setOpen(false)
     setResults([])
@@ -42,18 +54,6 @@ export function Header ({ stars }) {
   useEffect(() => {
     const readStorage = JSON.parse(localStorage.getItem('read')) || []
     setRead(readStorage.length)
-  }, [])
-
-  useEffect(() => {
-    window.addEventListener('storage', (event) => {
-      if (event.key === 'read') {
-        setRead(JSON.parse(event.newValue).length)
-      }
-    })
-
-    return () => {
-      window.removeEventListener('storage', () => {})
-    }
   }, [])
 
   const handleSelect = (result) => {

--- a/hooks/useEventListener.ts
+++ b/hooks/useEventListener.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+type UseEventListenerProps = {
+  eventName: string;
+  handler: (event: Event) => void;
+};
+export const useEventListener = ({
+  eventName,
+  handler
+}: UseEventListenerProps) => {
+  useEffect(() => {
+    window.addEventListener(eventName, (event) => {
+      handler(event)
+    })
+
+    return () => {
+      window.removeEventListener(eventName, () => {})
+    }
+  }, [eventName, handler])
+
+  return null
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preguntas-entrevista-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Descripción

- Se corrige el bug de que se pisen los posts leídos y que sucede cuando tienes varias pestañas abiertas de la pagina.
- Se añade mejora de sincronización de la cantidad de posts leídos en el header, de esta forma se actualiza cuando marcas o desmarcas un post desde otra pestaña
- Se añade mejora de sincronización sobre si el post está marcado como leído o no si tienes el mismo post abierto entre 2 o mas pestañas.

Video del problema en PROD
<video src="https://github.com/midudev/preguntas-entrevista-react/assets/63387375/2d0b8e2b-87f2-4a0e-a07b-f00b0db44ada" />

Video con la solución
<video src="https://github.com/midudev/preguntas-entrevista-react/assets/63387375/e41dfebb-3814-4d1a-84ee-a8283fab3fbb" />

este PR soluciona el issue declarado aquí: https://github.com/midudev/preguntas-entrevista-react/issues/69

## Checklist

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
- [x] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una línea separadora (`---`) al final de mi pregunta
