### PR TITLE
fix: increase z-index for Combobox options to improve visibility

### DIFF
--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -118,7 +118,7 @@ export function Header({ children }) {
         </label>
 
         {results.length > 0 && (
-          <Combobox.Options className='absolute z-10 w-full overflow-hidden bg-white/98 dark:bg-[#0f172a]/92 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-white/10 rounded-t-none shadow-xl shadow-black/20 dark:shadow-black/50 rounded-3xl backdrop-blur-md'>
+          <Combobox.Options className='absolute z-50 w-full overflow-hidden bg-white/98 dark:bg-[#0f172a]/92 text-gray-900 dark:text-gray-100 border border-gray-200 dark:border-white/10 rounded-t-none shadow-xl shadow-black/20 dark:shadow-black/50 rounded-3xl backdrop-blur-md'>
             {results.map(result => {
               const { item, matches } = result
               const { id, text } = item


### PR DESCRIPTION
## Descripción

Hola Midu, me he dado cuenta de que el background del dropdown del Combobox estaba roto (solo en la pagina de inicio). El problema era que las cards estaban por encima del background del dropdown. Adjunto captura:

<img width="1375" height="688" alt="Captura de pantalla 2026-04-01 a las 10 51 13" src="https://github.com/user-attachments/assets/664165e4-e215-4268-8cdd-fd7a9f7ce6ef" />

He aumentado el z-index (no es lo que más me gusta pero es como estaba y no quería aumentar la complejidad del fix) y ya funciona fino:

<img width="1202" height="699" alt="Captura de pantalla 2026-04-01 a las 10 48 33" src="https://github.com/user-attachments/assets/9df9aba5-5dac-47bd-868b-5422164481c8" />

## Checklist

- [X] He revisado que mi pregunta no está duplicada
- [X] He revisado que la gramática de mis cambios es correcta
- [ ] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una línea separadora (`---`) al final de mi pregunta
