### PR TITLE
fix: sync 'mark as read' status in the same tab using CustomEvent

### DIFF
--- a/app/components/ButtonRead.jsx
+++ b/app/components/ButtonRead.jsx
@@ -13,8 +13,9 @@ export function ButtonRead({ title }) {
 
   const handlerStorageListener = useCallback(
     event => {
-      if (event.key === 'read') {
-        setIsRead(JSON.parse(event.newValue).includes(title))
+      const { key, newValue } = event.detail ?? event
+      if (key === 'read') {
+        setIsRead(JSON.parse(newValue).includes(title))
       }
     },
     [title]
@@ -22,6 +23,11 @@ export function ButtonRead({ title }) {
 
   useEventListener({
     eventName: 'storage',
+    handler: handlerStorageListener,
+  })
+
+  useEventListener({
+    eventName: 'local-storage',
     handler: handlerStorageListener,
   })
 
@@ -36,7 +42,14 @@ export function ButtonRead({ title }) {
         read.push(title)
         setIsRead(true)
       }
-      window.localStorage.setItem('read', JSON.stringify(read))
+
+      const newValue = JSON.stringify(read)
+      window.localStorage.setItem('read', newValue)
+      window.dispatchEvent(
+        new CustomEvent('local-storage', {
+          detail: { key: 'read', newValue },
+        })
+      )
     }
   }
 

--- a/app/components/Header.jsx
+++ b/app/components/Header.jsx
@@ -35,13 +35,19 @@ export function Header({ children }) {
   )
 
   const handlerStorageListener = useCallback(event => {
-    if (event.key === 'read') {
-      setRead(JSON.parse(event.newValue).length)
+    const { key, newValue } = event.detail ?? event
+    if (key === 'read') {
+      setRead(JSON.parse(newValue).length)
     }
   }, [])
 
   useEventListener({
     eventName: 'storage',
+    handler: handlerStorageListener,
+  })
+
+  useEventListener({
+    eventName: 'local-storage',
     handler: handlerStorageListener,
   })
 

--- a/app/components/ReadStatusItem.jsx
+++ b/app/components/ReadStatusItem.jsx
@@ -14,8 +14,9 @@ export function ReadStatusItem({ id, text }) {
 
   const handlerStorageListener = useCallback(
     event => {
-      if (event.key === 'read') {
-        setIsRead(JSON.parse(event.newValue).includes(text))
+      const { key, newValue } = event.detail ?? event
+      if (key === 'read') {
+        setIsRead(JSON.parse(newValue).includes(text))
       }
     },
     [text]
@@ -23,6 +24,11 @@ export function ReadStatusItem({ id, text }) {
 
   useEventListener({
     eventName: 'storage',
+    handler: handlerStorageListener,
+  })
+
+  useEventListener({
+    eventName: 'local-storage',
     handler: handlerStorageListener,
   })
 


### PR DESCRIPTION
## Descripción
Corrige el botón "Marcar leído" que no actualizaba su estado visualmente 
en la misma pestaña hasta recargar la página.

**Causa raíz:** el evento nativo `storage` solo se dispara en otras 
pestañas, nunca en la que realiza la escritura.

**Solución:** se despacha un `CustomEvent('local-storage')` con el mismo 
payload (`key`, `newValue`) tras cada escritura en localStorage. Los 
componentes `ButtonRead`, `Header` y `ReadStatusItem` escuchan ahora 
ambos eventos usando el hook `useEventListener` ya existente en el proyecto.

La sincronización entre pestañas queda intacta.

Closes #127

## Checklist
- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
- [x] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una línea separadora (`---`) al final de mi pregunta