### PR TITLE
Activar marcado como leido en lista de preguntas

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,7 +98,7 @@ export default function Page() {
           Explora todas las preguntas disponibles y marca lo que ya has repasado
           para llevar un progreso real.
         </p>
-        <ListOfQuestions />
+        <ListOfQuestions showReadStatus={true} />
       </section>
     </>
   )


### PR DESCRIPTION
## Descripción

Actualmente en la lista de preguntas de la pantalla de Inicio no se están marcando como leídas las preguntas que se han definido como "Leído" en el post de la pregunta. Estoy pasando el prop `showReadStatus={true}` al componente  `ListOfQuestions` para que se active dicha ayuda visual, así el usuario puede saber que preguntas ya leyó.

`<ListOfQuestions showReadStatus={true} />`

Actualmente, sin la ayuda visual:
<img width="1467" height="1200" alt="Screenshot 2026-04-17 at 1 56 49 PM" src="https://github.com/user-attachments/assets/a8fce661-a437-4d0b-bacd-1298f929ad17" />

Con los cambios sugeridos:

<img width="1471" height="1147" alt="Screenshot 2026-04-17 at 1 57 09 PM" src="https://github.com/user-attachments/assets/9bfa20b1-85dc-4e5f-9d58-d34e5ce3dd5e" />




## Checklist

- [x] He revisado que mi pregunta no está duplicada
- [x] He revisado que la gramática de mis cambios es correcta
- [ ] He agregado un link de (`**[⬆ Volver a índice](#índice)**`) y una línea separadora (`---`) al final de mi pregunta
